### PR TITLE
Fix search dialog being covered up by browser UI on mobile

### DIFF
--- a/src/components/Dialog/Dialog.css
+++ b/src/components/Dialog/Dialog.css
@@ -10,6 +10,7 @@ body.body--dialog-open {
 
   width: 100vw;
   height: 100vh;
+  height: calc(var(--vh) * 100);
 
   background-color: rgba(26, 32, 39, 0.7);
   backdrop-filter: blur(4px);

--- a/src/components/SearchBar/SearchBar.js
+++ b/src/components/SearchBar/SearchBar.js
@@ -1,5 +1,6 @@
 import MeiliSearch from 'meilisearch';
 import React, { useCallback, useEffect, useState } from 'react';
+import useViewHeightCSS from '../../hooks/useViewHeightCSS';
 import Dialog from '../Dialog/Dialog';
 import Search from '../icons/Search';
 import './SearchBar.css';
@@ -11,6 +12,7 @@ const searchClient = new MeiliSearch({
 });
 
 const SearchBar = () => {
+  useViewHeightCSS();
   const [open, setOpen] = useState(false);
   const [filterBySection, setFilterBySection] = useState(true);
   const inputRef = React.createRef();

--- a/src/hooks/useViewHeightCSS.js
+++ b/src/hooks/useViewHeightCSS.js
@@ -1,0 +1,31 @@
+// We rely on a CSS variable to define a custom vh unit
+// because all mobile browsers don't compute their height the same way.
+// See https://css-tricks.com/the-trick-to-viewport-units-on-mobile/
+
+import React from 'react';
+
+const useViewHeightCSS = () => {
+  React.useEffect(() => {
+    const updateViewportHeight = () => {
+      console.log('updating');
+      if (document?.body && window) {
+        const vh = window.innerHeight * 0.01;
+        document.body.style.setProperty('--vh', `${vh}px`);
+      }
+    };
+
+    updateViewportHeight();
+
+    if (window) {
+      window.addEventListener('resize', updateViewportHeight);
+    }
+
+    return () => {
+      if (window) {
+        window.removeEventListener('resize', updateViewportHeight);
+      }
+    };
+  }, []);
+};
+
+export default useViewHeightCSS;


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/7467891/167499596-f794eaa3-1260-4faf-82bc-4bbcfd6894cf.png)

After:
![image](https://user-images.githubusercontent.com/7467891/167499669-8c30e8da-2d75-4728-b893-2c0f4d613f81.png)
