### PR TITLE
Add support for multiple themes

### DIFF
--- a/src/components/ThemeSettings.js
+++ b/src/components/ThemeSettings.js
@@ -1,12 +1,13 @@
 import React from 'react';
 import useDarkMode from 'use-dark-mode';
-import { useFontSettings } from '../hooks/theme-hooks';
+import { useFontSettings, useThemeSettings } from '../hooks/theme-hooks';
 import DarkModeOff from './icons/DarkModeOff';
 import DarkModeOn from './icons/DarkModeOn';
 
 const ThemeSettings = () => {
   const { value: isDarkMode, toggle: toggleDarkMode } = useDarkMode();
   useFontSettings();
+  useThemeSettings();
 
   return (
     <button className='dark-mode-toggle' onClick={toggleDarkMode}>

--- a/src/hooks/theme-hooks.js
+++ b/src/hooks/theme-hooks.js
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import '../styles/themes/black.css';
 
 // Custom hook
 export function useFontSettings() {
@@ -10,6 +11,22 @@ export function useFontSettings() {
     const element = window.document.body;
     element.style.fontFamily = font || null;
   }, [font, setFont]);
+}
+
+export function useThemeSettings() {
+  const [theme, setTheme] = useLocalStorage('theme-name');
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const element = window.document.body;
+    [...element.classList]
+      .filter((c) => c.startsWith('theme-'))
+      .forEach((c) => element.classList.remove(c));
+    element.classList.add(`theme-${theme || 'default'}`);
+  });
+
+  return { theme, setTheme };
 }
 
 // Source: https://usehooks.com/useLocalStorage/

--- a/src/hooks/theme-hooks.js
+++ b/src/hooks/theme-hooks.js
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import '../styles/themes/black.css';
+import '../styles/themes/solarized.css';
 
 // Custom hook
 export function useFontSettings() {

--- a/src/hooks/theme-hooks.js
+++ b/src/hooks/theme-hooks.js
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import '../styles/themes/black.css';
+import '../styles/themes/nord.css';
 import '../styles/themes/solarized.css';
 
 // Custom hook

--- a/src/styles/themes/black.css
+++ b/src/styles/themes/black.css
@@ -1,0 +1,10 @@
+@media not print {
+  body.dark-mode.theme-black {
+    --bgColor: #000000;
+    --cardColor: #161616;
+    --textColor: #dbdbdb;
+    --borderColor: #222222;
+    --scrollbarColor: hsla(0, 0%, 100%, 0.4);
+    --tableStripeBgColor: #262626aa;
+  }
+}

--- a/src/styles/themes/nord.css
+++ b/src/styles/themes/nord.css
@@ -1,0 +1,63 @@
+/* Nord Light */
+
+body {
+  --accentColor: #5e81ac;
+  --bgColor: #ffffff;
+  --cardColor: #f2f4f8;
+  --textColor: #4c566a;
+  --borderColor: #87a2c269;
+  --lighten20TextColor: #7b88a1;
+  --miniCodeBgColor: rgba(27, 31, 35, 0.05);
+  --scrollbarColor: #2e344088;
+  --tableStripeBgColor: #d8dee933;
+
+  --infoBorder: #5e81ac;
+  --tipBorder: #a3be8c;
+  --warningBorder: #ebcb8b;
+  --warningBorderTable: #ebcb8b88;
+  --warningBackground: #ebcb8b1a;
+  --dangerBorder: #da5961;
+  --dangerBackground: #ffe6e6;
+
+  --colorRed: #e03e3e;
+  --colorGreen: #0f7b6c;
+  --colorBlue: #0b6e99;
+  --colorPink: #ad1a72;
+  --colorPurple: #6940a5;
+  --colorYellow: #dfab01;
+  --colorOrange: #d9730d;
+  --colorBrown: #64473a;
+}
+
+/* Nord Dark */
+
+@media not print {
+  body.dark-mode {
+    --accentColor: #88c0d0;
+    --bgColor: #242933;
+    --cardColor: #2e3440;
+    --textColor: #eceff4;
+    --borderColor: #3b4252;
+    --lighten20TextColor: #abb9cf;
+    --miniCodeBgColor: #3b4252;
+    --scrollbarColor: #4c566a88;
+    --tableStripeBgColor: #3b425288;
+
+    --infoBorder: #5e81ac;
+    --tipBorder: #a3be8c;
+    --warningBorder: #ebcb8b;
+    --warningBorderTable: #ebcb8b55;
+    --warningBackground: #ebcb8b1a;
+    --dangerBorder: #c87981;
+    --dangerBackground: #c879811a;
+
+    --colorRed: #c87981;
+    --colorGreen: #a3be8c;
+    --colorBlue: #5e81ac;
+    --colorPink: #fec3ee;
+    --colorPurple: #b48ead;
+    --colorYellow: #ebcb8b;
+    --colorOrange: #d08770;
+    --colorBrown: #bc854b;
+  }
+}

--- a/src/styles/themes/solarized.css
+++ b/src/styles/themes/solarized.css
@@ -1,0 +1,45 @@
+/* Solarized Light */
+
+body.theme-solarized {
+  --accentColor: #268bd2;
+  --bgColor: #eee8d5;
+  --cardColor: #fdf6e3;
+  --textColor: #2c3e50;
+  --borderColor: #c3beb0;
+  --lighten20TextColor: #476582;
+  --miniCodeBgColor: rgba(27, 31, 35, 0.05);
+  --scrollbarColor: rgba(0, 0, 0, 0.4);
+  --tableStripeBgColor: #f6f8faaa;
+
+  --infoBorder: #268bd2;
+  --tipBorder: #859900;
+  --warningBorder: #b58900;
+  --warningBorderTable: #b5890055;
+  --warningBackground: #b589001a;
+  --dangerBorder: #dc322f;
+  --dangerBackground: #dc322f26;
+
+  --colorRed: #dc322f;
+  --colorGreen: #859900;
+  --colorBlue: #2aa198;
+  --colorPink: #d33682;
+  --colorPurple: #6c71c4;
+  --colorYellow: #b58900;
+  --colorOrange: #cb4b16;
+  --colorBrown: #9e571a;
+}
+
+/* Solarized Dark */
+
+@media not print {
+  body.dark-mode.theme-solarized {
+    --bgColor: #002b36;
+    --cardColor: #073642;
+    --textColor: #e2e2e2;
+    --borderColor: #045266;
+    --lighten20TextColor: #e8e8e8;
+    --miniCodeBgColor: hsla(0, 0%, 100%, 0.1);
+    --scrollbarColor: hsla(0, 0%, 100%, 0.4);
+    --tableStripeBgColor: #024859aa;
+  }
+}


### PR DESCRIPTION
This PR does not include the UI to change the themes, only the code to load the correct theme.

To do that, you must change local storage manually, by setting the `theme-name` property, as such:
![image](https://user-images.githubusercontent.com/7467891/172069574-f53e3e94-b6ed-4ba6-afb1-109c1fc7c8bb.png)

**Themes included** (in addition to the default themes):

- [x] Black (`black`)
- [x] Solarized (`solarized`)
- [x] Nord (`nord`)

All themes still respect the light/dark setting.

<details>
<summary>Screenshots</summary>

**Black**  
![image](https://user-images.githubusercontent.com/7467891/172069684-320e6af6-b2a7-4fd7-ad8a-1454a54190cf.png)

**Solarized Dark**  
![image](https://user-images.githubusercontent.com/7467891/172069644-71327944-ea86-47c5-8920-af36b1d5bce5.png)

**Solarized Light**  
![image](https://user-images.githubusercontent.com/7467891/172069651-6902090f-41d9-413d-a955-90e692179d17.png)

**Nord Dark**
![image](https://user-images.githubusercontent.com/7467891/172134398-d703007a-5bbe-4628-9cb9-889d19111dbd.png)

**Nord Light**
![image](https://user-images.githubusercontent.com/7467891/172134465-85c861a9-d914-4660-9ca2-f1a1e2f7e0c0.png)

</details>