### PR TITLE
Update `package.json#license` field to match `LICENSE.md`

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "format:content": "prettier -w 'content/**/*.md'",
     "format-win": "prettier -w 'src\\**\\*.{js,md,vue}'"
   },
-  "license": "MIT",
+  "license": "GPL-3.0",
   "devDependencies": {
     "prettier": "^2.7.1"
   },


### PR DESCRIPTION
[`LICENSE.md`](https://github.com/leic-pt/resumos-leic/blob/d81c1ab0470c8a51de5cf584c4c64688381b0826/LICENSE.md) is GPL-3.0 but [`package.json#license`](https://github.com/leic-pt/resumos-leic/blob/d81c1ab0470c8a51de5cf584c4c64688381b0826/package.json#L21) is MIT: update the latter to match the former.