### PR TITLE
Fix text not showing up correctly in complex SVGs in Chromium

### DIFF
--- a/plugins/gatsby-remark-post-image-data/gatsby-browser.js
+++ b/plugins/gatsby-remark-post-image-data/gatsby-browser.js
@@ -1,0 +1,36 @@
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll(`object[type="image/svg+xml"]`).forEach(swapObjectByInlineSvg);
+});
+
+/**
+ * Chromium did not want to correctly load MathJax inside the draw.io SVGs
+ * when they were wrapped in an <object> tag.
+ * This function takes an <object> element, gets its content and places the SVG inline,
+ * avoiding the <object> tag.
+ */
+const swapObjectByInlineSvg = async (el) => {
+  let svgElement = el.contentDocument?.querySelector('svg');
+  if (!svgElement) {
+    // Don't do anything if there is no SVG element
+    return;
+  }
+
+  const svgSource = svgElement.outerHTML;
+
+  let divWrapper = document.createElement('div');
+  divWrapper.innerHTML = svgSource;
+
+  // Copy attributes from old element to new
+  el.getAttributeNames()
+    .filter((attr) => ['data', 'type', 'onload'].indexOf(attr) === -1) // remove stale attributes
+    .forEach((attr) => {
+      divWrapper.setAttribute(attr, el.getAttribute(attr));
+    });
+
+  divWrapper.classList.add('object-svg-inline');
+
+  el.parentElement.insertBefore(divWrapper, el);
+  el.parentElement.removeChild(el);
+};
+
+window.swapObjectByInlineSvg = swapObjectByInlineSvg;

--- a/plugins/gatsby-remark-post-image-data/gatsby-browser.js
+++ b/plugins/gatsby-remark-post-image-data/gatsby-browser.js
@@ -1,5 +1,3 @@
-document.addEventListener('DOMContentLoaded', swapAlreadyLoadedObjects);
-
 const swapAlreadyLoadedObjects = () => {
   document.querySelectorAll(`object[type="image/svg+xml"]`).forEach(swapObjectByInlineSvg);
 };
@@ -35,5 +33,6 @@ const swapObjectByInlineSvg = async (el) => {
   el.parentElement.removeChild(el);
 };
 
+document.addEventListener('DOMContentLoaded', swapAlreadyLoadedObjects);
 swapAlreadyLoadedObjects();
 window.swapObjectByInlineSvg = swapObjectByInlineSvg;

--- a/plugins/gatsby-remark-post-image-data/gatsby-browser.js
+++ b/plugins/gatsby-remark-post-image-data/gatsby-browser.js
@@ -1,6 +1,8 @@
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener('DOMContentLoaded', swapAlreadyLoadedObjects);
+
+const swapAlreadyLoadedObjects = () => {
   document.querySelectorAll(`object[type="image/svg+xml"]`).forEach(swapObjectByInlineSvg);
-});
+};
 
 /**
  * Chromium did not want to correctly load MathJax inside the draw.io SVGs
@@ -33,4 +35,5 @@ const swapObjectByInlineSvg = async (el) => {
   el.parentElement.removeChild(el);
 };
 
+swapAlreadyLoadedObjects();
 window.swapObjectByInlineSvg = swapObjectByInlineSvg;

--- a/plugins/gatsby-remark-post-image-data/index.js
+++ b/plugins/gatsby-remark-post-image-data/index.js
@@ -25,6 +25,7 @@ const onImageVisit = (node) => {
     data.hName = 'object';
     hProperties.data = node.url;
     hProperties.type = 'image/svg+xml';
+    hProperties.onload = 'swapObjectByInlineSvg(this);';
     node.type = 'object';
   }
 };

--- a/plugins/gatsby-remark-post-image-data/index.js
+++ b/plugins/gatsby-remark-post-image-data/index.js
@@ -25,7 +25,7 @@ const onImageVisit = (node) => {
     data.hName = 'object';
     hProperties.data = node.url;
     hProperties.type = 'image/svg+xml';
-    hProperties.onload = 'swapObjectByInlineSvg(this);';
+    hProperties.onload = 'swapObjectByInlineSvg && swapObjectByInlineSvg(this);';
     node.type = 'object';
   }
 };

--- a/plugins/gatsby-remark-post-image-data/index.js
+++ b/plugins/gatsby-remark-post-image-data/index.js
@@ -25,7 +25,7 @@ const onImageVisit = (node) => {
     data.hName = 'object';
     hProperties.data = node.url;
     hProperties.type = 'image/svg+xml';
-    hProperties.onload = 'swapObjectByInlineSvg && swapObjectByInlineSvg(this);';
+    hProperties.onload = 'swapObjectByInlineSvg?.(this);';
     node.type = 'object';
   }
 };

--- a/plugins/gatsby-remark-post-image-data/index.js
+++ b/plugins/gatsby-remark-post-image-data/index.js
@@ -25,7 +25,7 @@ const onImageVisit = (node) => {
     data.hName = 'object';
     hProperties.data = node.url;
     hProperties.type = 'image/svg+xml';
-    hProperties.onload = 'swapObjectByInlineSvg?.(this);';
+    hProperties.onload = 'window.swapObjectByInlineSvg?.(this);';
     node.type = 'object';
   }
 };

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -63,21 +63,25 @@ a {
 @media not print {
   body.dark-mode .gatsby-resp-image-wrapper[data-dark='1'],
   body.dark-mode object[data-dark='1'],
+  body.dark-mode .object-svg-inline[data-dark='1'],
   body.dark-mode img[data-dark='1'] {
     filter: invert(1) hue-rotate(180deg) saturate(5);
   }
   body.dark-mode .gatsby-resp-image-wrapper[data-dark='2'],
   body.dark-mode object[data-dark='2'],
+  body.dark-mode .object-svg-inline[data-dark='2'],
   body.dark-mode img[data-dark='2'] {
     filter: invert(1) hue-rotate(180deg) saturate(3);
   }
   body.dark-mode .gatsby-resp-image-wrapper[data-dark='3'],
   body.dark-mode object[data-dark='3'],
+  body.dark-mode .object-svg-inline[data-dark='3'],
   body.dark-mode img[data-dark='3'] {
     filter: invert(1) hue-rotate(180deg);
   }
   body.dark-mode .gatsby-resp-image-wrapper[data-dark='4'],
   body.dark-mode object[data-dark='4'],
+  body.dark-mode .object-svg-inline[data-dark='4'],
   body.dark-mode img[data-dark='4'] {
     filter: invert(1);
   }

--- a/src/styles/markdown.css
+++ b/src/styles/markdown.css
@@ -35,7 +35,8 @@ body.dark-mode .content a:hover {
 }
 
 .content img,
-.content object {
+.content object,
+.content .object-svg-inline svg {
   max-width: 100%;
   /* center images */
   display: block;


### PR DESCRIPTION
Left: Firefox, Right: Brave (Chromium)
![image](https://user-images.githubusercontent.com/7467891/202852147-ae0e270d-e7e2-4034-a39c-c43f489e3891.png)

This bug was introduced by #852, since the SVG rendered correctly before that (`<img>` vs `<object>`).

This PR aims to do a quick fix by adding an `onLoad` handler to the `<object>` elements, and replacing them with the inline SVG contents (it doesn't fetch the SVGs again, it uses the content already loaded by `<object>`).