### PR TITLE
Allow puppeteer to cache browser in project directory

### DIFF
--- a/.puppeteerrc.cjs
+++ b/.puppeteerrc.cjs
@@ -1,0 +1,12 @@
+const { join } = require('path');
+
+/**
+ * @type {import("puppeteer").Configuration}
+ */
+module.exports = {
+  // Changes the cache location for Puppeteer.
+  // This is because when deploying to Vercel, ~/.cache isn't cached between builds.
+  cacheDirectory: process.env['PUPPETEER_IN_PROJECT_DIRECTORY']
+    ? join(__dirname, 'node_modules', '.cache-puppeteer')
+    : undefined,
+};

--- a/README.md
+++ b/README.md
@@ -81,6 +81,13 @@ Antes de fazer um commit, é recomendado executar o `prettier` (se usarem um edi
 yarn format
 ```
 
+### Configurações Avançadas
+
+Quando se está a configurar o _deployment_, de forma a incluir o browser nas pastas
+que ficam em cache, pode ser necessário definir
+a _environment variable_ `PUPPETEER_IN_PROJECT_DIRECTORY`, que guarda o browser
+do Puppeteer na pasta do projeto em vez de na _home directory_.
+
 ## Parceiros
 
 [![Powered by Vercel](./src/images/powered-by-vercel.svg)](https://vercel.com/?utm_source=leic-pt&utm_campaign=oss)


### PR DESCRIPTION
After #907, the site wouldn't build on Vercel if `node_modules` was cached.
This fixes that issue by allowing the Chromium browser downloaded by Puppeteer to be cached like before.

The environment variable `PUPPETEER_IN_PROJECT_DIRECTORY` must be set to a truth-y value (i.e. `1`) to turn on this (old) behavior.