### PR TITLE
Add engine to package.json to require Node 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,5 +52,8 @@
     "react-dom": "^18.2.0",
     "remark-directive": "^1.0.1",
     "use-dark-mode": "^2.3.1"
+  },
+  "engines": {
+    "node": ">=18.0.0"
   }
 }


### PR DESCRIPTION
Following #907, the minimum Node.js version required is no 18.
This adds an `engine` configuration to `package.json`, it order to give a more friendly error message.