### PR TITLE
Fix site crashing on search

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,8 +50,7 @@
     "puppeteer": "^19.5.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "remark-directive": "^1.0.1",
-    "use-dark-mode": "^2.3.1"
+    "remark-directive": "^1.0.1"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/src/components/SearchBar/Highlight.js
+++ b/src/components/SearchBar/Highlight.js
@@ -1,9 +1,10 @@
 import React from 'react';
 
 const Highlight = ({ component = 'p', hit, attribute, ...props }) => {
+  const Component = component;
   if (hit._formatted[attribute]) {
     return (
-      <component
+      <Component
         dangerouslySetInnerHTML={{
           __html: hit._formatted[attribute],
         }}
@@ -11,7 +12,7 @@ const Highlight = ({ component = 'p', hit, attribute, ...props }) => {
       />
     );
   }
-  return <component {...props}>{hit[attribute]}</component>;
+  return <Component {...props}>{hit[attribute]}</Component>;
 };
 
 export default Highlight;

--- a/src/components/SearchBar/Hit.js
+++ b/src/components/SearchBar/Hit.js
@@ -22,7 +22,9 @@ const Hit = ({ hit, source, getItemProps, onItemClick }) => {
           {[1, 2, 3, 4, 5, 6]
             .map((level) => `hierarchy_lvl${level}`)
             .filter((attr) => !!hit[attr])
-            .map((attribute) => <Highlight key={attribute} attribute={attribute} hit={hit} />)
+            .map((attribute) => (
+              <Highlight component='span' key={attribute} attribute={attribute} hit={hit} />
+            ))
             .reduce((acc, el, i) => {
               if (i === 0) {
                 return [...acc, el];

--- a/src/components/ThemeSettings.js
+++ b/src/components/ThemeSettings.js
@@ -1,17 +1,16 @@
 import React from 'react';
-import useDarkMode from 'use-dark-mode';
-import { useFontSettings, useThemeSettings } from '../hooks/theme-hooks';
+import { useDarkMode, useFontSettings, useThemeSettings } from '../hooks/theme-hooks';
 import DarkModeOff from './icons/DarkModeOff';
 import DarkModeOn from './icons/DarkModeOn';
 
 const ThemeSettings = () => {
-  const { value: isDarkMode, toggle: toggleDarkMode } = useDarkMode();
+  const { darkMode, toggle: toggleDarkMode } = useDarkMode();
   useFontSettings();
   useThemeSettings();
 
   return (
     <button className='dark-mode-toggle' onClick={toggleDarkMode}>
-      {isDarkMode ? <DarkModeOn /> : <DarkModeOff />}
+      {darkMode ? <DarkModeOn /> : <DarkModeOff />}
     </button>
   );
 };

--- a/src/hooks/theme-hooks.js
+++ b/src/hooks/theme-hooks.js
@@ -85,7 +85,8 @@ export function useLocalStorage(key, initialValue) {
 }
 
 function usePrefersDarkMode() {
-  const mediaQuery = window?.matchMedia('(prefers-color-scheme: dark)');
+  const w = typeof window === 'undefined' ? null : window;
+  const mediaQuery = w?.matchMedia('(prefers-color-scheme: dark)');
 
   const [dark, setDark] = useState(mediaQuery?.matches || false);
 

--- a/src/hooks/theme-hooks.js
+++ b/src/hooks/theme-hooks.js
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import '../styles/themes/black.css';
 import '../styles/themes/nord.css';
 import '../styles/themes/solarized.css';
@@ -31,6 +31,30 @@ export function useThemeSettings() {
   return { theme, setTheme };
 }
 
+export function useDarkMode() {
+  const [darkModeStored, setDarkModeStored] = useLocalStorage('darkMode', null);
+  const prefersDarkMode = usePrefersDarkMode();
+
+  const darkMode = darkModeStored ?? prefersDarkMode;
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return null;
+
+    const element = window.document.body;
+    if (darkMode) {
+      element.classList.add('dark-mode');
+      element.classList.remove('light-mode');
+    } else {
+      element.classList.add('light-mode');
+      element.classList.remove('dark-mode');
+    }
+  }, [darkMode]);
+
+  const toggle = useCallback(() => setDarkModeStored(!darkMode), [setDarkModeStored, darkMode]);
+
+  return { darkMode, toggle };
+}
+
 // Source: https://usehooks.com/useLocalStorage/
 export function useLocalStorage(key, initialValue) {
   const [storedValue, setStoredValue] = useState(() => {
@@ -58,4 +82,22 @@ export function useLocalStorage(key, initialValue) {
   };
 
   return [storedValue, setValue];
+}
+
+function usePrefersDarkMode() {
+  const mediaQuery = window?.matchMedia('(prefers-color-scheme: dark)');
+
+  const [dark, setDark] = useState(mediaQuery?.matches || false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return null;
+
+    const handler = mediaQuery.addEventListener('change', (event) =>
+      setDark(event.matches || false)
+    );
+
+    return () => mediaQuery.removeEventListener('change', handler);
+  }, [mediaQuery]);
+
+  return dark;
 }

--- a/src/hooks/theme-hooks.js
+++ b/src/hooks/theme-hooks.js
@@ -16,7 +16,7 @@ export function useFontSettings() {
 }
 
 export function useThemeSettings() {
-  const [theme, setTheme] = useLocalStorage('theme-name');
+  const [theme, setTheme] = useLocalStorage('themeName');
 
   useEffect(() => {
     if (typeof window === 'undefined') return;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2248,11 +2248,6 @@
     "@typescript-eslint/types" "4.33.0"
     eslint-visitor-keys "^2.0.0"
 
-"@use-it/event-listener@^0.1.2":
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/@use-it/event-listener/-/event-listener-0.1.7.tgz#443a9b6df87f2f2961b74d42997ce723a7078623"
-  integrity sha512-hgfExDzUU9uTRTPDCpw2s9jWTxcxmpJya3fK5ADpf5VDpSy8WYwY/kh28XE0tUcbsljeP8wfan48QvAQTSSa3Q==
-
 "@vercel/webpack-asset-relocator-loader@^1.7.3":
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/@vercel/webpack-asset-relocator-loader/-/webpack-asset-relocator-loader-1.7.3.tgz#e65ca1fd9feb045039788f9b4710e5acc84b01b0"
@@ -11007,21 +11002,6 @@ url-loader@^4.1.1:
     loader-utils "^2.0.0"
     mime-types "^2.1.27"
     schema-utils "^3.0.0"
-
-use-dark-mode@^2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/use-dark-mode/-/use-dark-mode-2.3.1.tgz#d506349c7b7e09e9977cb8a6ab4470896aa3779a"
-  integrity sha512-hmcdJR96tTustRQdaQwe6jMrZHnmPqXBxgy4jaQ4gsfhwajsCpjECuq9prgDe9XxMx/f9r96o2/md6O4Lwhwjg==
-  dependencies:
-    "@use-it/event-listener" "^0.1.2"
-    use-persisted-state "^0.3.0"
-
-use-persisted-state@^0.3.0:
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/use-persisted-state/-/use-persisted-state-0.3.3.tgz#5e0f2236967cec7c34de33abc07ae6818e7c7451"
-  integrity sha512-pCNlvYC8+XjRxwnIut4teGC9f2p9aD88R8OGseQGZa2dvqG/h1vEGk1vRE1IZG0Vf161UDpn+NlW4+UGubQflQ==
-  dependencies:
-    "@use-it/event-listener" "^0.1.2"
 
 util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"


### PR DESCRIPTION
This was unrelated to search.
It was related to unfocusing `<input>` elements, because this library https://github.com/donavon/use-event-listener was wrongfully adding a listener to window instead of the media query.
However, it seems like the culprit is Webpack, since the code of the library is correct and hasn't changed in years. Inspecting the code, we see it doesn't match before and after transpilation.

![image](https://user-images.githubusercontent.com/7467891/212497417-bf54c93e-44be-4ecf-b746-62cd84c8b35f.png)
![image](https://user-images.githubusercontent.com/7467891/212497406-4d442f32-d0e8-4411-a99e-fd6557020b2c.png)

Introduced after #907 