### PR TITLE
[SD] Fix precision formula for Algoritmo de Cristian

### DIFF
--- a/content/sd/0003-tempo-e-sincronizacao.md
+++ b/content/sd/0003-tempo-e-sincronizacao.md
@@ -163,7 +163,7 @@ demora $RTT$, o tempo estimado estará errado por $\frac{RTT}{2}$.
 A precisão deste algoritmo é, portanto, $\frac{RTT}{2}$.
 
 Pode-se melhorar a precisão caso se conheça o tempo mínimo de transmissão,
-ficando $\frac{RTT - RTT_{min}}{2}$.
+ficando $\frac{RTT}{2} - RTT_{min}$.
 
 Este algoritmo é simples, no entanto, tem um único ponto de falha. Se o
 servidor de tempo falhar, o sistema não consegue sincronizar os relógios.


### PR DESCRIPTION
<!--
Obrigado por contribuíres para os Resumos LEIC!

Para garantir consistência, todos os títulos de pull requests devem seguir o formato:
[Sigla da UC] Breve descrição (com a primeira letra maiúscula e sem ponto final)

Exemplos:
[PE] Add variáveis aleatórias
[Fis1] Cleanup cheatsheets
[TC] Add reductions and Teorema de Savitch
[CDI-I] Fix typos

Abaixo podes escrever mais detalhes sobre as tuas alterações, se relevante!
-->

A formula que lá esta era (rtt - rtt(min)) / 2 mas o rtt(min) devia estar fora da fração

Sources/prova:
https://pt.wikipedia.org/wiki/Algoritmo_de_Cristian (vale o que vale, especialmente em português)

Adicionalmente:
Tempo de viagem total é RTT, assumindo o RTT/2 para calcular o tempo do relógio temos no pior caso que a viagem de lá para cá é instantânea (por exemplo) portanto a precisão seria RTT/2 - 0
Sabendo que existe um tempo mínimo (RTTmin) temos o pior caso RTTmin de lá para cá, ou seja, RTT/2 - RTTmin
