### PR TITLE
chore(nix flake): configure puppeteer to allow local build

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -15,6 +15,11 @@
             nodejs
             yarn
           ];
+
+          shellHook = ''
+            export PUPPETEER_SKIP_DOWNLOAD=1
+            export PUPPETEER_EXECUTABLE_PATH=${pkgs.chromium.outPath}/bin/chromium
+          '';
         };
       }
     );


### PR DESCRIPTION
The chromium binary puppeteer downloads isn't compatible with NixOS (for obvious reasons), so we need to use nixpkgs' version of chromium.