### PR TITLE
fix(style): set edit page link width to fit its content

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -294,10 +294,11 @@ button {
 }
 
 .edit-link {
+  width: fit-content;
+  align-self: flex-end;
   display: flex;
   align-items: center;
   gap: 5px;
-  justify-content: flex-end;
   color: var(--textColor);
   opacity: 60%;
   transition: color 1s cubic-bezier(0.075, 0.82, 0.165, 1),


### PR DESCRIPTION
Currently, the edit page link spans across the whole page content width, making it possible to hover/click on it where there's no icon/text:

![image](https://github.com/leic-pt/resumos-leic/assets/48092637/a4440a24-1aac-4319-a6bc-c973f992ba4a)

This behavior is most likely undesired, so I propose setting its width to fit its content and docking it to the right (maintaining the old appearance/layout).

