### PR TITLE
feat: display each font text with the corresponding font in theme settings

### DIFF
--- a/src/components/ThemeSettings/DropdownSelect/DropdownOption.js
+++ b/src/components/ThemeSettings/DropdownSelect/DropdownOption.js
@@ -1,13 +1,16 @@
 import React, { useContext } from 'react';
 import { DropdownContext } from './DropdownSelect';
 
-const DropdownOption = ({ value, children }) => {
+const DropdownOption = ({ value, children, font }) => {
   const { id, value: selectedValue, onChange } = useContext(DropdownContext);
+
+  const style = font ? { fontFamily: font, fontSize: '17px' } : {};
 
   return (
     <button
       className={`keep-focus-${id} dropdown-option${value === selectedValue ? ' selected' : ''}`}
       onClick={() => onChange(value)}
+      style = { style }
     >
       {children}
     </button>

--- a/src/components/ThemeSettings/DropdownSelect/DropdownOption.js
+++ b/src/components/ThemeSettings/DropdownSelect/DropdownOption.js
@@ -10,7 +10,7 @@ const DropdownOption = ({ value, children, font }) => {
     <button
       className={`keep-focus-${id} dropdown-option${value === selectedValue ? ' selected' : ''}`}
       onClick={() => onChange(value)}
-      style = { style }
+      style={style}
     >
       {children}
     </button>

--- a/src/components/ThemeSettings/DropdownSelect/DropdownOption.js
+++ b/src/components/ThemeSettings/DropdownSelect/DropdownOption.js
@@ -1,11 +1,8 @@
 import React, { useContext } from 'react';
 import { DropdownContext } from './DropdownSelect';
-import { fonts } from '../../../hooks/theme-hooks';
 
-const DropdownOption = ({ value, children }) => {
+const DropdownOption = ({ value, children, style }) => {
   const { id, value: selectedValue, onChange } = useContext(DropdownContext);
-
-  const style = fonts[value] ? { fontFamily: fonts[value]['cssFamily'], fontSize: '17px' } : {};
 
   return (
     <button

--- a/src/components/ThemeSettings/DropdownSelect/DropdownOption.js
+++ b/src/components/ThemeSettings/DropdownSelect/DropdownOption.js
@@ -1,10 +1,11 @@
 import React, { useContext } from 'react';
 import { DropdownContext } from './DropdownSelect';
+import { fonts } from '../../../hooks/theme-hooks';
 
-const DropdownOption = ({ value, children, font }) => {
+const DropdownOption = ({ value, children }) => {
   const { id, value: selectedValue, onChange } = useContext(DropdownContext);
 
-  const style = font ? { fontFamily: font, fontSize: '17px' } : {};
+  const style = fonts[value] ? { fontFamily: fonts[value]['cssFamily'], fontSize: '17px' } : {};
 
   return (
     <button

--- a/src/components/ThemeSettings/DropdownSelect/DropdownSelect.js
+++ b/src/components/ThemeSettings/DropdownSelect/DropdownSelect.js
@@ -1,7 +1,6 @@
-import React, { useCallback, useMemo, useState, useEffect } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import DropdownArrow from '../../icons/DropdownArrow';
 import './DropdownSelect.css';
-import { fonts } from '../../../hooks/theme-hooks';
 
 const DropdownContext = React.createContext({ id: 'unknown', value: null, onChange: () => {} });
 
@@ -35,23 +34,6 @@ const DropdownSelect = ({ id = 'unknown', value, onChange, children }) => {
     },
     [onChange, close]
   );
-
-  // Loading all the fonts when the component is built
-  useEffect(() => {
-    Object.values(fonts).forEach((font) => {
-      if (font.url) {
-        const link = document.createElement('link');
-        // temporary solution until openDyslexic font has support for subset loading
-        if (font === fonts['openDyslexic']) {
-          link.href = font.url;
-        } else {
-          link.href = font.url.concat('&text=', font.displayName);
-        }
-        link.rel = 'stylesheet';
-        document.head.appendChild(link);
-      }
-    });
-  }, []);
 
   return (
     <div

--- a/src/components/ThemeSettings/DropdownSelect/DropdownSelect.js
+++ b/src/components/ThemeSettings/DropdownSelect/DropdownSelect.js
@@ -41,7 +41,12 @@ const DropdownSelect = ({ id = 'unknown', value, onChange, children }) => {
     Object.values(fonts).forEach((font) => {
       if (font.url) {
         const link = document.createElement('link');
-        link.href = font.url;
+        // temporary solution until openDyslexic font has support for subset loading
+        if (font === fonts['openDyslexic']) {
+          link.href = font.url;
+        } else {
+          link.href = font.url.concat('&text=', font.displayName);
+        }
         link.rel = 'stylesheet';
         document.head.appendChild(link);
       }

--- a/src/components/ThemeSettings/DropdownSelect/DropdownSelect.js
+++ b/src/components/ThemeSettings/DropdownSelect/DropdownSelect.js
@@ -1,6 +1,7 @@
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState, useEffect } from 'react';
 import DropdownArrow from '../../icons/DropdownArrow';
 import './DropdownSelect.css';
+import { fonts } from '../../../hooks/theme-hooks'
 
 const DropdownContext = React.createContext({ id: 'unknown', value: null, onChange: () => {} });
 
@@ -34,6 +35,18 @@ const DropdownSelect = ({ id = 'unknown', value, onChange, children }) => {
     },
     [onChange, close]
   );
+
+  // Carregar todas as fontes quando o componente é montado
+  useEffect(() => {
+    Object.values(fonts).forEach(font => {
+      if (font.url) {
+        const link = document.createElement('link');
+        link.href = font.url;
+        link.rel = 'stylesheet';
+        document.head.appendChild(link);
+      }
+    });
+  }, []);
 
   return (
     <div

--- a/src/components/ThemeSettings/DropdownSelect/DropdownSelect.js
+++ b/src/components/ThemeSettings/DropdownSelect/DropdownSelect.js
@@ -1,7 +1,7 @@
 import React, { useCallback, useMemo, useState, useEffect } from 'react';
 import DropdownArrow from '../../icons/DropdownArrow';
 import './DropdownSelect.css';
-import { fonts } from '../../../hooks/theme-hooks'
+import { fonts } from '../../../hooks/theme-hooks';
 
 const DropdownContext = React.createContext({ id: 'unknown', value: null, onChange: () => {} });
 
@@ -36,9 +36,9 @@ const DropdownSelect = ({ id = 'unknown', value, onChange, children }) => {
     [onChange, close]
   );
 
-  // Carregar todas as fontes quando o componente é montado
+  // Loading all the fonts when the component is built
   useEffect(() => {
-    Object.values(fonts).forEach(font => {
+    Object.values(fonts).forEach((font) => {
       if (font.url) {
         const link = document.createElement('link');
         link.href = font.url;

--- a/src/components/ThemeSettings/ThemeSettings.js
+++ b/src/components/ThemeSettings/ThemeSettings.js
@@ -1,5 +1,6 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import {
+  fonts,
   useContentWidth,
   useDarkMode,
   useFontSettings,
@@ -30,6 +31,22 @@ const ThemeSettings = () => {
   const { textAlign, setTextAlign } = useTextAlign();
   const { fontLoader, font, setFont } = useFontSettings();
   const { theme, setTheme } = useThemeSettings();
+
+  // Load (previews of) all the fonts to show their preview on dropdown
+  const fontPreviewsLoader = useMemo(
+    () =>
+      Object.values(fonts)
+        .filter((font) => font.url)
+        .map((font) => {
+          let href = font.url;
+          // For Google Fonts, avoid loading the entire font and load only the required text
+          if (font.url?.startsWith('https://fonts.googleapis.com/css2?')) {
+            href = `${href}&text=${encodeURIComponent(font.displayName)}`;
+          }
+          return <link href={href} rel='stylesheet'></link>;
+        }),
+    []
+  );
 
   return (
     <>
@@ -111,19 +128,19 @@ const ThemeSettings = () => {
             </button>
           </div>
         </Option>
+        {panelOpen && fontPreviewsLoader}
         {fontLoader}
         <Option name='Font'>
           <DropdownSelect id='font' value={font} onChange={(v) => setFont(v)}>
-            <DropdownOption value='roboto'>Roboto (default)</DropdownOption>
-            <DropdownOption value='comicNeue'>Comic Neue</DropdownOption>
-            <DropdownOption value='indieFlower'>Indie Flower</DropdownOption>
-            <DropdownOption value='nunito'>Nunito</DropdownOption>
-            <DropdownOption value='openDyslexic'>OpenDyslexic</DropdownOption>
-            <DropdownOption value='openSans'>Open Sans</DropdownOption>
-            <DropdownOption value='cursive'>cursive (system)</DropdownOption>
-            <DropdownOption value='monospace'>monospace (system)</DropdownOption>
-            <DropdownOption value='sansSerif'>sans-serif (system)</DropdownOption>
-            <DropdownOption value='serif'>serif (system)</DropdownOption>
+            {Object.entries(fonts).map(([fontName, fontOptions]) => (
+              <DropdownOption
+                key={fontName}
+                value={fontName}
+                style={{ fontFamily: fontOptions.cssFamily }}
+              >
+                {fontOptions.displayName}
+              </DropdownOption>
+            ))}
           </DropdownSelect>
         </Option>
       </SidePanel>

--- a/src/components/ThemeSettings/ThemeSettings.js
+++ b/src/components/ThemeSettings/ThemeSettings.js
@@ -115,36 +115,16 @@ const ThemeSettings = () => {
         {fontLoader}
         <Option name='Font'>
           <DropdownSelect id='font' value={font} onChange={(v) => setFont(v)}>
-            <DropdownOption value='roboto' font={fonts['roboto']['cssFamily']}>
-              Roboto (default)
-            </DropdownOption>
-            <DropdownOption value='comicNeue' font={fonts['comicNeue']['cssFamily']}>
-              Comic Neue
-            </DropdownOption>
-            <DropdownOption value='indieFlower' font={fonts['indieFlower']['cssFamily']}>
-              Indie Flower
-            </DropdownOption>
-            <DropdownOption value='nunito' font={fonts['nunito']['cssFamily']}>
-              Nunito
-            </DropdownOption>
-            <DropdownOption value='openDyslexic' font={fonts['openDyslexic']['cssFamily']}>
-              OpenDyslexic
-            </DropdownOption>
-            <DropdownOption value='openSans' font={fonts['openSans']['cssFamily']}>
-              Open Sans
-            </DropdownOption>
-            <DropdownOption value='cursive' font={fonts['cursive']['cssFamily']}>
-              cursive (system)
-            </DropdownOption>
-            <DropdownOption value='monospace' font={fonts['monospace']['cssFamily']}>
-              monospace (system)
-            </DropdownOption>
-            <DropdownOption value='sansSerif' font={fonts['sansSerif']['cssFamily']}>
-              sans-serif (system)
-            </DropdownOption>
-            <DropdownOption value='serif' font={fonts['serif']['cssFamily']}>
-              serif (system)
-            </DropdownOption>
+            <DropdownOption value='roboto'>Roboto (default)</DropdownOption>
+            <DropdownOption value='comicNeue'>Comic Neue</DropdownOption>
+            <DropdownOption value='indieFlower'>Indie Flower</DropdownOption>
+            <DropdownOption value='nunito'>Nunito</DropdownOption>
+            <DropdownOption value='openDyslexic'>OpenDyslexic</DropdownOption>
+            <DropdownOption value='openSans'>Open Sans</DropdownOption>
+            <DropdownOption value='cursive'>cursive (system)</DropdownOption>
+            <DropdownOption value='monospace'>monospace (system)</DropdownOption>
+            <DropdownOption value='sansSerif'>sans-serif (system)</DropdownOption>
+            <DropdownOption value='serif'>serif (system)</DropdownOption>
           </DropdownSelect>
         </Option>
       </SidePanel>

--- a/src/components/ThemeSettings/ThemeSettings.js
+++ b/src/components/ThemeSettings/ThemeSettings.js
@@ -19,6 +19,7 @@ import SidePanel from '../SidePanel';
 import DropdownOption from './DropdownSelect/DropdownOption';
 import DropdownSelect from './DropdownSelect/DropdownSelect';
 import Option from './Option';
+import { fonts } from '../../hooks/theme-hooks'
 import './ThemeSettings.css';
 
 const ThemeSettings = () => {
@@ -113,18 +114,19 @@ const ThemeSettings = () => {
         </Option>
         {fontLoader}
         <Option name='Font'>
-          <DropdownSelect id='font' value={font} onChange={(v) => setFont(v)}>
-            <DropdownOption value='roboto'>Roboto (default)</DropdownOption>
-            <DropdownOption value='comicNeue'>Comic Neue</DropdownOption>
-            <DropdownOption value='indieFlower'>Indie Flower</DropdownOption>
-            <DropdownOption value='nunito'>Nunito</DropdownOption>
-            <DropdownOption value='openDyslexic'>OpenDyslexic</DropdownOption>
-            <DropdownOption value='openSans'>Open Sans</DropdownOption>
-            <DropdownOption value='cursive'>cursive (system)</DropdownOption>
-            <DropdownOption value='monospace'>monospace (system)</DropdownOption>
-            <DropdownOption value='sansSerif'>sans-serif (system)</DropdownOption>
-            <DropdownOption value='serif'>serif (system)</DropdownOption>
-          </DropdownSelect>
+        <DropdownSelect id='font' value={font} onChange={(v) => setFont(v)}>
+          <DropdownOption value='roboto' font={fonts['roboto']['cssFamily']}>Roboto (default)</DropdownOption>
+          <DropdownOption value='comicNeue' font={fonts['comicNeue']['cssFamily']}>Comic Neue</DropdownOption>
+          <DropdownOption value='indieFlower' font={fonts['indieFlower']['cssFamily']} >Indie Flower</DropdownOption>
+          <DropdownOption value='nunito' font={fonts['nunito']['cssFamily']}>Nunito</DropdownOption>
+          <DropdownOption value='openDyslexic' font={fonts['openDyslexic']['cssFamily']}>OpenDyslexic</DropdownOption>
+          <DropdownOption value='openSans' font={fonts['openSans']['cssFamily']}>Open Sans</DropdownOption>
+          <DropdownOption value='cursive' font={fonts['cursive']['cssFamily']}>cursive (system)</DropdownOption>
+          <DropdownOption value='monospace' font={fonts['monospace']['cssFamily']}>monospace (system)</DropdownOption>
+          <DropdownOption value='sansSerif' font={fonts['sansSerif']['cssFamily']}>sans-serif (system)</DropdownOption>
+          <DropdownOption value='serif' font={fonts['serif']['cssFamily']}>serif (system)</DropdownOption>
+        </DropdownSelect>
+
         </Option>
       </SidePanel>
     </>

--- a/src/components/ThemeSettings/ThemeSettings.js
+++ b/src/components/ThemeSettings/ThemeSettings.js
@@ -19,7 +19,7 @@ import SidePanel from '../SidePanel';
 import DropdownOption from './DropdownSelect/DropdownOption';
 import DropdownSelect from './DropdownSelect/DropdownSelect';
 import Option from './Option';
-import { fonts } from '../../hooks/theme-hooks'
+import { fonts } from '../../hooks/theme-hooks';
 import './ThemeSettings.css';
 
 const ThemeSettings = () => {
@@ -114,19 +114,38 @@ const ThemeSettings = () => {
         </Option>
         {fontLoader}
         <Option name='Font'>
-        <DropdownSelect id='font' value={font} onChange={(v) => setFont(v)}>
-          <DropdownOption value='roboto' font={fonts['roboto']['cssFamily']}>Roboto (default)</DropdownOption>
-          <DropdownOption value='comicNeue' font={fonts['comicNeue']['cssFamily']}>Comic Neue</DropdownOption>
-          <DropdownOption value='indieFlower' font={fonts['indieFlower']['cssFamily']} >Indie Flower</DropdownOption>
-          <DropdownOption value='nunito' font={fonts['nunito']['cssFamily']}>Nunito</DropdownOption>
-          <DropdownOption value='openDyslexic' font={fonts['openDyslexic']['cssFamily']}>OpenDyslexic</DropdownOption>
-          <DropdownOption value='openSans' font={fonts['openSans']['cssFamily']}>Open Sans</DropdownOption>
-          <DropdownOption value='cursive' font={fonts['cursive']['cssFamily']}>cursive (system)</DropdownOption>
-          <DropdownOption value='monospace' font={fonts['monospace']['cssFamily']}>monospace (system)</DropdownOption>
-          <DropdownOption value='sansSerif' font={fonts['sansSerif']['cssFamily']}>sans-serif (system)</DropdownOption>
-          <DropdownOption value='serif' font={fonts['serif']['cssFamily']}>serif (system)</DropdownOption>
-        </DropdownSelect>
-
+          <DropdownSelect id='font' value={font} onChange={(v) => setFont(v)}>
+            <DropdownOption value='roboto' font={fonts['roboto']['cssFamily']}>
+              Roboto (default)
+            </DropdownOption>
+            <DropdownOption value='comicNeue' font={fonts['comicNeue']['cssFamily']}>
+              Comic Neue
+            </DropdownOption>
+            <DropdownOption value='indieFlower' font={fonts['indieFlower']['cssFamily']}>
+              Indie Flower
+            </DropdownOption>
+            <DropdownOption value='nunito' font={fonts['nunito']['cssFamily']}>
+              Nunito
+            </DropdownOption>
+            <DropdownOption value='openDyslexic' font={fonts['openDyslexic']['cssFamily']}>
+              OpenDyslexic
+            </DropdownOption>
+            <DropdownOption value='openSans' font={fonts['openSans']['cssFamily']}>
+              Open Sans
+            </DropdownOption>
+            <DropdownOption value='cursive' font={fonts['cursive']['cssFamily']}>
+              cursive (system)
+            </DropdownOption>
+            <DropdownOption value='monospace' font={fonts['monospace']['cssFamily']}>
+              monospace (system)
+            </DropdownOption>
+            <DropdownOption value='sansSerif' font={fonts['sansSerif']['cssFamily']}>
+              sans-serif (system)
+            </DropdownOption>
+            <DropdownOption value='serif' font={fonts['serif']['cssFamily']}>
+              serif (system)
+            </DropdownOption>
+          </DropdownSelect>
         </Option>
       </SidePanel>
     </>

--- a/src/components/ThemeSettings/ThemeSettings.js
+++ b/src/components/ThemeSettings/ThemeSettings.js
@@ -19,7 +19,6 @@ import SidePanel from '../SidePanel';
 import DropdownOption from './DropdownSelect/DropdownOption';
 import DropdownSelect from './DropdownSelect/DropdownSelect';
 import Option from './Option';
-import { fonts } from '../../hooks/theme-hooks';
 import './ThemeSettings.css';
 
 const ThemeSettings = () => {

--- a/src/hooks/theme-hooks.js
+++ b/src/hooks/theme-hooks.js
@@ -4,7 +4,7 @@ import '../styles/themes/gruvbox.css';
 import '../styles/themes/nord.css';
 import '../styles/themes/solarized.css';
 
-const fonts = {
+export const fonts = {
   roboto: {
     cssFamily: 'Roboto, sans-serif',
     url: 'https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap',

--- a/src/hooks/theme-hooks.js
+++ b/src/hooks/theme-hooks.js
@@ -8,17 +8,17 @@ export const fonts = {
   roboto: {
     cssFamily: 'Roboto, sans-serif',
     url: 'https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap',
-    displayName: 'Roboto%20(default)',
+    displayName: 'Roboto (default)',
   },
   comicNeue: {
     cssFamily: 'Comic Neue, sans-serif',
     url: 'https://fonts.googleapis.com/css2?family=Comic+Neue:wght@400;700&display=swap',
-    displayName: 'Comic%20Neue',
+    displayName: 'Comic Neue',
   },
   indieFlower: {
     cssFamily: 'Indie Flower, cursive',
     url: 'https://fonts.googleapis.com/css2?family=Indie+Flower&display=swap',
-    displayName: 'Indie%20Flower',
+    displayName: 'Indie Flower',
   },
   nunito: {
     cssFamily: 'Nunito, sans-serif',
@@ -33,19 +33,23 @@ export const fonts = {
   openSans: {
     cssFamily: 'Open Sans, Roboto, sans-serif',
     url: 'https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;700&display=swap',
-    displayName: 'Open%20Sans',
+    displayName: 'Open Sans',
   },
   cursive: {
     cssFamily: 'cursive',
+    displayName: 'cursive (system)',
   },
   monospace: {
     cssFamily: 'monospace',
+    displayName: 'monospace (system)',
   },
   sansSerif: {
     cssFamily: 'sans-serif',
+    displayName: 'sans-serif (system)',
   },
   serif: {
     cssFamily: 'serif',
+    displayName: 'serif (system)',
   },
 };
 

--- a/src/hooks/theme-hooks.js
+++ b/src/hooks/theme-hooks.js
@@ -8,26 +8,32 @@ export const fonts = {
   roboto: {
     cssFamily: 'Roboto, sans-serif',
     url: 'https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap',
+    displayName: 'Roboto%20(default)',
   },
   comicNeue: {
     cssFamily: 'Comic Neue, sans-serif',
     url: 'https://fonts.googleapis.com/css2?family=Comic+Neue:wght@400;700&display=swap',
+    displayName: 'Comic%20Neue',
   },
   indieFlower: {
     cssFamily: 'Indie Flower, cursive',
     url: 'https://fonts.googleapis.com/css2?family=Indie+Flower&display=swap',
+    displayName: 'Indie%20Flower',
   },
   nunito: {
     cssFamily: 'Nunito, sans-serif',
     url: 'https://fonts.googleapis.com/css2?family=Nunito:wght@400;700&display=swap',
+    displayName: 'Nunito',
   },
   openDyslexic: {
     cssFamily: 'OpenDyslexicRegular, Roboto, sans-serif',
     url: 'https://cdn.jsdelivr.net/npm/open-dyslexic@1.0.3/open-dyslexic-regular.min.css',
+    displayName: 'OpenDyslexic',
   },
   openSans: {
     cssFamily: 'Open Sans, Roboto, sans-serif',
     url: 'https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;700&display=swap',
+    displayName: 'Open%20Sans',
   },
   cursive: {
     cssFamily: 'cursive',


### PR DESCRIPTION
I am submitting a pull request where I have made changes to the source code to enhance the font selection dropdown menu on the website. 

Now, each font name in the dropdown is displayed in its corresponding font style. 

This update makes the font selection process more intuitive and user-friendly, as users can see a preview of each font without having to test them one by one.

# Old Appearance:
![image](https://github.com/leic-pt/resumos-leic/assets/66919841/0768c3b3-2bd9-4f87-b37c-ec6564f1837d)

# New Appearance:
![image](https://github.com/leic-pt/resumos-leic/assets/66919841/54d6dea0-2f66-4071-b30d-a2c470719587)

