### PR TITLE
chore: use project's prettier version for prettier CI

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -10,18 +10,14 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          # Make sure the actual branch is checked out when running on pull requests
-          ref: ${{github.event.pull_request.head.ref}}
-          repository: ${{github.event.pull_request.head.repo.full_name}}
-          # This is important to fetch the changes to the previous commit
-          fetch-depth: 0
+        uses: actions/checkout@v4.2.2
 
-      - name: Prettify code
-        uses: creyD/prettier_action@v4.3
-        with:
-          prettier_options: --write **/*.{js,md}
-          only_changed: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run Prettier
+        run: |
+          export PRETTIER_VERSION="$(yarn list --pattern prettier --depth 0 -s --json --no-progress | jq -r '.data.trees[0].name' | cut -d'@' -f2)"
+          if [[ -z "$PRETTIER_VERSION" ]]; then
+            echo "Failed to detect prettier version"
+            exit 1
+          fi
+          echo "Found prettier version: $PRETTIER_VERSION"
+          npx prettier@"$PRETTIER_VERSION" --check '**/*.{js,md,vue}'


### PR DESCRIPTION
Drops the creyD/prettier_action and instead just runs prettier directly.

Closes #1035

<!--
Obrigado por contribuíres para os Resumos LEIC!

Para garantir consistência, todos os títulos de pull requests devem seguir o formato:
[Sigla da UC] Breve descrição (com a primeira letra maiúscula e sem ponto final)

Exemplos:
[PE] Add variáveis aleatórias
[Fis1] Cleanup cheatsheets
[TC] Add reductions and Teorema de Savitch
[CDI-I] Fix typos

Abaixo podes escrever mais detalhes sobre as tuas alterações, se relevante!
-->
